### PR TITLE
New algorithmic denylist for october 5th

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,6 @@
 {
   "serial": 2023100501,
+  "report_prefix": "https://shdw-drive.genesysgo.net/EfbthUQtshuaZdpoPZfDi3688KJKv5uk8PWRKZ8C1kcY/",
   "hash": "u+t4HXOnw5TpCL3HQkjvEohpYBKV0ZgDbSkXRAl9nls=",
   "signatures": [
     {

--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,10 @@
 {
-  "serial": 2023100301,
-  "report_prefix": "https://shdw-drive.genesysgo.net/3DvkYWGineRxY2zCG4Yexwo5GP8kaRooaUaSzWf1DiFg/",
-  "hash": "dbY8K6a7w0unYoRkcDU/HKuZkehM8SW0F6fyXcGtxoQ=",
+  "serial": 2023100501,
+  "hash": "u+t4HXOnw5TpCL3HQkjvEohpYBKV0ZgDbSkXRAl9nls=",
   "signatures": [
     {
       "address": "13hSNQ6KDnFcG8zKJg79HFcKNPcqg4f4hSnxaSjpUsyh7UAvRak",
-      "signature": "NBo2VPbR/hghunB7TmY8oyUESBLjXpqIh7NoXoKfegqRBTIddTl+Pl/yfwPnaJfVYUheKPlxuJE0HN6W9qOTBg=="
+      "signature": "3ctyECBTUS0MrsovN1koRJPLi5nRtVdRhVK/eTBm343MnYTkbyPZqK7N/o2D3kDmF9cP6+dKKZlKEgqHl8sdBg=="
     }
   ]
 }


### PR DESCRIPTION
This denylist changes some of the classifer parameters:

* Terrain intersection threshold lowered to 500km*m from 1000km*m
* Witness count limit for witness reciprocity lowered from 100 to 50
* Distance insensitivity curve relaxed by 500km

These changes reflect our increasing confidence in the terrain and witness reciprocity classifiers, and handles a case where we were too strict on hotspots 5km or less apart.