### PR TITLE
New denylist for october 17:

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,11 @@
 {
-  "serial": 2023100802,
-  "report_prefix": "https://shdw-drive.genesysgo.net/8oTShhJYodzZ6pDzC2JBYPGpyoJ4MPLWZmJ8rJN8swv5/",
-  "hash": "rjrNGsRrUV1TTZ20KRM291X37AJJQI32TVTv2aghQFQ=",
+  "serial": 2023101701,
+  "report_prefix": "https://shdw-drive.genesysgo.net/9in3XbMqeTFdacTE45M7et4BtRgVUYPJ6ow19vkPtEbH/",
+  "hash": "PDt1T0wtPfOwWKd4+qfofPEhoSZv7bhfAjUrj6JPQN4=",
   "signatures": [
     {
       "address": "13hSNQ6KDnFcG8zKJg79HFcKNPcqg4f4hSnxaSjpUsyh7UAvRak",
-      "signature": "JdYEj1AtA6f3el4U6nBPvIYy2Wmrs8oApxOftlHlidCzj0bjl2oQwuazG21DNkdLTyQ1qj8Fv3eE8nCduzl/BQ=="
+      "signature": "i7yTtvO8wqA9AHn8K9Sgy86VhnhcGxIeiu7ixQRG8YZ1cGnDNzKW3DrvywPhTYzDy/hmT9Q1lm7ZlUjDKp0cCw=="
     }
   ]
 }


### PR DESCRIPTION
The primary change was to implement 'carryover' from the previous denylist. This means that any nodes/edges that did not have any data for them over the 2 week sampling period are carried forward. This prevents hotspots from simply being turned off for two weeks to escape the denylist and then being turned back on.

All other denylist parameters remain the same as the previous week, and no new classifiers are added.