### PR TITLE
Denylist for november 6th to november 20th

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,11 @@
 {
-  "serial": 2023111301,
-  "hash": "zPZ3fo4rNs4BkzSGubsfdc8pNGgF34GzQWabqL16Xd0=",
-  "report_prefix": "https://shdw-drive.genesysgo.net/7RTLPvgVpQu5AVJpyvanc8JpeR6aAexd9dEABsn6WrAX/",
+  "serial": 2023112101,
+  "hash": "g93sfa6K/RsJhewwNnzVPQJpz5CNsaVXgjrg3JCqogc=",
+  "report_prefix": "https://shdw-drive.genesysgo.net/Fizi7iL5c9b4gHPnz11vGv68cR6rGSgXEGbMhQkkoYPU/",
   "signatures": [
     {
       "address": "13hSNQ6KDnFcG8zKJg79HFcKNPcqg4f4hSnxaSjpUsyh7UAvRak",
-      "signature": "BOTWCeJmVPBaHimtHD+6Z89Un4/MDAtJR0+fXB2wTgOOSIRIjv722C+UWRNiDPS12/xXrnN4N4LOOy80ySE5DA=="
+      "signature": "4scLC5k/WX9+RKZs6sGgfqfaypy2Ybbvtgbi/io+vNrJo3B12f5SGQaIcB9zhBZNT1lQM5seVlP6T9eb+fBlDA=="
     }
   ]
 }


### PR DESCRIPTION
This denylist adds support for carryover count to the descriptor file. All other parameters remain unchanged.