### PR TITLE
Denylist for Jan 29 - Feb 12. Includes antenna-split classifier changes

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,11 @@
 {
-  "serial": 2024020501,
-  "hash": "zLQBkD7SlIleUPZD5FcZLimbN1kSbRQ6mPVrCe0TdkA=",
-  "report_prefix": "https://shdw-drive.genesysgo.net/6Zei7LwWa6TRgWh1Xn8boX22jwWu8F4LYnj73EUXZ1Yv/",
+  "serial": 2024021201,
+  "hash": "VS53AmjYo4RSGAV9NjEKpLeWdXfzvMCHcKE+/NxvtPs=",
+  "report_prefix": "https://shdw-drive.genesysgo.net/95UN4deWPqto1RKewnU9MFaZReADHBwK2KrH6Z2k39cZ/",
   "signatures": [
     {
       "address": "13hSNQ6KDnFcG8zKJg79HFcKNPcqg4f4hSnxaSjpUsyh7UAvRak",
-      "signature": "lHPTT5e3QK7+uHdK0xZHKMw7zMgrGCkqSx5q8+fiabvRe3v5Z1EX5F771gJOaJE4B438hv3wTEY8jMO7olG2BQ=="
+      "signature": "0deyjVfeWXQIMQVMLoVLje1AYhNGHFEp+ym7gplfqRpd0bzfBa34N7ndhfy0MvUopBuLFgpB5fpLf2DJ7BUKAw=="
     }
   ]
 }


### PR DESCRIPTION
The antenna split classifier now considers -20 RSSI asserted more than 1km away to be antenna splitting/clustering and will trigger a node ban.