### PR TITLE
Denylist for Feb 05 to Feb 19, reduces reciprocity classifier

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,11 @@
 {
-  "serial": 2024021201,
-  "hash": "VS53AmjYo4RSGAV9NjEKpLeWdXfzvMCHcKE+/NxvtPs=",
-  "report_prefix": "https://shdw-drive.genesysgo.net/95UN4deWPqto1RKewnU9MFaZReADHBwK2KrH6Z2k39cZ/",
+  "serial": 2024021901,
+  "hash": "QSzU6ANLGlZAmPjvSYuK6jzUE28tzmogXmnUZADQfpg=",
+  "report_prefix": "https://shdw-drive.genesysgo.net/Hp5bsLe9mjcAjtR1bgJSfdUZSfYuZm5okSsLTsuqGSVT/",
   "signatures": [
     {
       "address": "13hSNQ6KDnFcG8zKJg79HFcKNPcqg4f4hSnxaSjpUsyh7UAvRak",
-      "signature": "0deyjVfeWXQIMQVMLoVLje1AYhNGHFEp+ym7gplfqRpd0bzfBa34N7ndhfy0MvUopBuLFgpB5fpLf2DJ7BUKAw=="
+      "signature": "phergujDGARoazNVmMkh6fBSveDOAJLCfZ00OkkCusGW5QeK7JERZyRSWusUhHZRCfMjFdIUHfIdFSNkwa0pAA=="
     }
   ]
 }


### PR DESCRIPTION
As the simple witness reciprocity checker for beacon/witness only hotspots has moved into the oracle, we have reduced the denylist reciprocity classifier into a more specific one that looks for hotspots that have both witnesses and beacons, but no hotspots in common on those lists. This affects only a very small amount of hotspots (43 for this list).

All other denylist parameters remain unchanged from last week.