### PR TITLE
New denylist for Feb 26 to Mar 11, updates antenna classifier:

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,11 @@
 {
-  "serial": 2024030401,
-  "hash": "uOWxNmrnOqkbmP939bb6o4TZiWkgclEi5rJCn+4ZCHk=",
-  "report_prefix": "https://shdw-drive.genesysgo.net/5rzN4pi2igkiCU3iy6b4Rj4UzZGmRZxSM1TxneAHJTW3/",
+  "serial": 2024031101,
+  "hash": "7abNFy8o/QmhibRhl9b6/MMLaxHLnGHpXmZt/IeQNTo=",
+  "report_prefix": "https://shdw-drive.genesysgo.net/Eu1CTiJ3jNEq5nwPtzeheBk3CgcvVGaEjLxpT99uxVdd/",
   "signatures": [
     {
       "address": "13hSNQ6KDnFcG8zKJg79HFcKNPcqg4f4hSnxaSjpUsyh7UAvRak",
-      "signature": "pwDkELkT/KnAajBIHwtYSLvPmTUG8Ggqkzk5gi2g3R3AGuzqY90+7OFFD92LcEkOv7+x1ROo7v3GvG0JHUWJDQ=="
+      "signature": "4TAEJ5YZVHb1hybpPotHQTKJ9dav9ptY0yQa/VspLfR5jIgQG0VNcJruhMbE2GpZsdctwcXBrUMwfWp52F1/Bg=="
     }
   ]
 }


### PR DESCRIPTION
https://docs.helium.com/devblog/2024/03/11/updated-antenna-denylist-classifier