### PR TITLE
Denylist for Mar 11-25, contains bugfix for antenna classifier

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,7 @@
 {
   "serial": 2024032501,
   "hash": "m5+/sQe3c9/j9dCOAMoq3Dlh11nTolBzGyhHuqWqCMU=",
+  "report_prefix": "https://shdw-drive.genesysgo.net/HxUnMCVMcQUxDeLELtS6wC7AWXjEnT11VeTiRR3s1Chq/",
   "signatures": [
     {
       "address": "13hSNQ6KDnFcG8zKJg79HFcKNPcqg4f4hSnxaSjpUsyh7UAvRak",

--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,10 @@
 {
-  "serial": 2024031801,
-  "hash": "7HfjXguG+T/RoX9Fp0oXWMRBjvSuSdy1UdpvxgufhrE=",
-   "report_prefix": "https://shdw-drive.genesysgo.net/4mFLW9xC2rZkyBxHj4YSQPrstDQNUjoPgGvmZwyyhLHt/",
+  "serial": 2024032501,
+  "hash": "m5+/sQe3c9/j9dCOAMoq3Dlh11nTolBzGyhHuqWqCMU=",
   "signatures": [
     {
       "address": "13hSNQ6KDnFcG8zKJg79HFcKNPcqg4f4hSnxaSjpUsyh7UAvRak",
-      "signature": "ZuB/uwTRhM74P/QWt/uI6GsG/XZN1LGfJyytgBMcbssHKRlQlQVIBTMsrC38SHwLdTMqH4UxOtBmx0y/09r8CA=="
+      "signature": "lmVyNMsxWkfa6JhatVL0D7Gbqta16yGP7LhNH3bqMATXdMYEpYXM4CBL2BKCOCs4qNqqrfDrqAXhAVbqgS0PAA=="
     }
   ]
 }


### PR DESCRIPTION
Last week it was discovered that the antenna classifier was incorrectly having significant amounts of false negatives. After repairing this bug it was also discovered that about 21,000 hotspots were being classified using the selected criteria. Since no counterexamples had been found, it was decided to continue with the existing classifier parameters and with the bugfix. This means that this week's list is significantly larger than it was before.

Denylist statistics:

carryover (nodes):		193
carryover (edges):		3108393

Node classifiers:
antenna split/too close:	21332
disjoint reciprocity:		38

Edge classifiers
terrain intersection:		2559791
distance insensitivity:		2102778
ingest latency:			16074