### PR TITLE
New denylist for April 15 to April 29, no classifier changes

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,11 @@
 {
-  "serial": 2024042201,
-  "hash": "iL7dQ1qjGk95Mxorz+V6dwaigxRkXT5O0m1Vp3px+rU=",
-  "report_prefix": "https://shdw-drive.genesysgo.net/4X62vNgfFuzoAp9nnr4yiGUgsoC2oYTB7zt7n2rGGNo9/",
+  "serial": 2024042901,
+  "hash": "tTjGt7GbS32KOmFyr6PrvUjlAgJhLUbsRqApY8S6qhM=",
+  "report_prefix": "https://shdw-drive.genesysgo.net/8STApKVjs393sbtH8uUTfnJgDAxPcrfVMypGhLWBbokz/",
   "signatures": [
     {
       "address": "13hSNQ6KDnFcG8zKJg79HFcKNPcqg4f4hSnxaSjpUsyh7UAvRak",
-      "signature": "8mwW/ZDBL1zGY9h0ymmHL6opDox6a9XSJQcZSgFiezteo3h2wOF3TZOOK1Fn48/VUZZtGyM4DNonJceE2aF9BQ=="
+      "signature": "GmJfoCj6vrpSY6A9a9CZ7sGFLzrNfpA7/N7kHuIizyuSDCsxMN0rvFtOXiX16iqCLv7uKzaUW/kcKjEiAcAZBA=="
     }
   ]
 }


### PR DESCRIPTION
Denylist statistics:

carryover (nodes): 2048
carryover (edges): 2864534

Node classifiers:
antenna split/too close: 13924
disjoint reciprocity: 43

Edge classifiers
terrain intersection: 2668787
distance insensitivity: 2161635
ingest latency: 10614