### PR TITLE
Denylist for Apr 22 to May 06, no classifier changes

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,11 @@
 {
-  "serial": 2024042901,
-  "hash": "tTjGt7GbS32KOmFyr6PrvUjlAgJhLUbsRqApY8S6qhM=",
-  "report_prefix": "https://shdw-drive.genesysgo.net/8STApKVjs393sbtH8uUTfnJgDAxPcrfVMypGhLWBbokz/",
+  "serial": 2024050601,
+  "hash": "gYewN5n8FrRtnUvvsWpM0Uq1tBss4nXejAjt/HcyS1s=",
+  "report_prefix": "https://shdw-drive.genesysgo.net/jLFZy1NjEfe1Dp3p8yaUuK17erZG8fkbJS9UvWZbRsB/",
   "signatures": [
     {
       "address": "13hSNQ6KDnFcG8zKJg79HFcKNPcqg4f4hSnxaSjpUsyh7UAvRak",
-      "signature": "GmJfoCj6vrpSY6A9a9CZ7sGFLzrNfpA7/N7kHuIizyuSDCsxMN0rvFtOXiX16iqCLv7uKzaUW/kcKjEiAcAZBA=="
+      "signature": "rnxtGfjMkmdxNv4BtHMXjMQTXcAi5D+EWaSQMBeVB6FS4iTYEKhE1w4QBUKVPrRR1dGxvSpaQm3og/a0vHGyCA=="
     }
   ]
 }


### PR DESCRIPTION
Denylist statistics:

carryover (nodes): 2174
carryover (edges): 2878491

Node classifiers:
antenna split/too close: 13160
disjoint reciprocity: 42

Edge classifiers
terrain intersection: 2755222
distance insensitivity: 2097384
ingest latency: 7978