### PR TITLE
Denylist for Dec 09 to Dec 23, no classifier changes, community bans

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,11 @@
 {
-  "serial": 2024121601,
-  "hash": "7JB/VD3CK10Z4ECyOGr3z/jyxLdyPKIq6zDs53eMgns=",
-  "report_prefix": "https://shdw-drive.genesysgo.net/6JTzhP3z3uEGjyMbAxfEw3BtBE6tNXcwTdbeYwzamED5/",
+  "serial": 2024122301,
+  "hash": "XjqpggsjHvPo9Hoo5QtS/eUv16WE82dFrwcoFbWDjR0=",
+  "report_prefix": "https://shdw-drive.genesysgo.net/7pVJoUSuPaTyQqkJHX2HmBfZ1ZXmBT5o6dUmZonUVuYa/",
   "signatures": [
     {
       "address": "13hSNQ6KDnFcG8zKJg79HFcKNPcqg4f4hSnxaSjpUsyh7UAvRak",
-      "signature": "+6r6Tv2b903se6E0cMRKFwPwUCQ2lAKnJbgsM1wQ77K0JRUD0/k3gztsbKs/apG/sFpQSyTQY4OYm9kt8df3Cw=="
+      "signature": "dFk0YDap9TypnJ2zmjlkHrWE/JeNhLIWiqEZtuw8TMwKmFp+u/eoOGhKTRQQjYChZDO1V7lr5a9g/TPB+2h2DA=="
     }
   ]
 }


### PR DESCRIPTION
Summary
----
carryover (nodes): **1837**
carryover (edges): **5081675**
community bans: **98950**

Node classifiers:
antenna split/too close: **6973**
disjoint reciprocity: **84**

Edge classifiers:
terrain intersection: **1769111**
distance insensitivity: **1803844**
ingest latency: **5481**