### PR TITLE
Denylist for Jan 06 to Jan 20, no classifier changes

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,11 @@
 {
-  "serial": 2025011301,
-  "hash": "5610fvnCEXJFpGx7AkiD0ul2+n7lvOahVcBCzwAJfPg=",
-  "report_prefix": "https://shdw-drive.genesysgo.net/4L1ie2gq1tvS1FebtUQByh5AFc6Yk88cypcE9KNowkEH/",
+  "serial": 2025012401,
+  "hash": "69AK6QuGCUjWrpvjG5bpdoKsOelmgKjFsCCYLf3XW/s=",
+  "report_prefix": "https://shdw-drive.genesysgo.net/AWddHJcfKYA7VfCnWbgb7dSHMDwj4c7Wnpp6kwjFP36j/",
   "signatures": [
     {
       "address": "13hSNQ6KDnFcG8zKJg79HFcKNPcqg4f4hSnxaSjpUsyh7UAvRak",
-      "signature": "qUj3A0CBK9qb+TSQlsneLZq4Czx9o0WwIUwrr0+jVgidEJsccRPYXV1vzsqMWgBvDSc2XBQEYUf4DdvbWR/vCw=="
+      "signature": "yxrXpyNG9lw8NMU3yqvULk0N3RHOrTcSVeC6cbfmO6ODsdHwB7n2Wt1HGkVcp1SjnQB42cIqwKpMcJLg4bZxBA=="
     }
   ]
 }


### PR DESCRIPTION
Summary
----
carryover (nodes): **1769**
carryover (edges): **5622412**
community inclusions: **98950**

Node classifiers:
antenna split/too close: **6728**
disjoint reciprocity: **54**

Edge classifiers:
terrain intersection: **1408396**
distance insensitivity: **1240574**
ingest latency: **1644**

NOTE:
- We had some issues with shdw-drive, hence the delay in the denylist

TODO:
- [x] Wait for shdw upload to complete