### PR TITLE
Denylist for Jan 13 to Jan 27, no classifier changes

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,11 @@
 {
-  "serial": 2025012401,
-  "hash": "69AK6QuGCUjWrpvjG5bpdoKsOelmgKjFsCCYLf3XW/s=",
-  "report_prefix": "https://shdw-drive.genesysgo.net/AWddHJcfKYA7VfCnWbgb7dSHMDwj4c7Wnpp6kwjFP36j/",
+  "serial": 2025012701,
+  "hash": "T/7vv1oRMw9GRPr2/ycccdP45qjg8rOjndkqYhyJivY=",
+  "report_prefix": "https://shdw-drive.genesysgo.net/cjNMbsnxZpsKiopLSjeZRe8mKiPqkdXe6FfiXLi4SJc/",
   "signatures": [
     {
       "address": "13hSNQ6KDnFcG8zKJg79HFcKNPcqg4f4hSnxaSjpUsyh7UAvRak",
-      "signature": "yxrXpyNG9lw8NMU3yqvULk0N3RHOrTcSVeC6cbfmO6ODsdHwB7n2Wt1HGkVcp1SjnQB42cIqwKpMcJLg4bZxBA=="
+      "signature": "goHkr20rKdmR+4Ukh1Rxvwa9jjGvSCe3FpUWoQRJ2FTLTgJyK+IFtGfhA2oJsc0tpmHVtEt/Jw5NWI2uXNlcAg=="
     }
   ]
 }


### PR DESCRIPTION
Summary
----
carryover (nodes): **1930**
carryover (edges): **5672270**
community inclusions: **98950**

Node classifiers:
antenna split/too close: **6595**
disjoint reciprocity: **59**

Edge classifiers:
terrain intersection: **1376241**
distance insensitivity: **1262055**
ingest latency: **1030**

TODO:
- [x] Wait for shdw upload